### PR TITLE
allow 2022.1 and upcoming 2022.2 Versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 # Docker Registry Explorer Changelog
 
+## [1.0.8-stable] - 2022-05-31
+### Added
+- Support for 2022.2 versions
+
 ## [1.0.7-stable] - 2021-10-05
 ### Added
 - Support for self-signed certs

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,12 +3,12 @@
 
 pluginGroup = com.github.exidcuter.dockerregistryexplorer
 pluginName_ = docker-registry-explorer
-pluginVersion = 1.0.7-stable
+pluginVersion = 1.0.8-stable
 pluginSinceBuild = 203
-pluginUntilBuild = 220.*
+pluginUntilBuild = 222.*
 # Plugin Verifier integration -> https://github.com/JetBrains/gradle-intellij-plugin#plugin-verifier-dsl
 # See https://jb.gg/intellij-platform-builds-list for available build versions
-pluginVerifierIdeVersions = 2020.3, 2021.1, 2021.2
+pluginVerifierIdeVersions = 2020.3, 2021.1, 2021.2, 2022.1, 2022.2
 
 platformType = IC
 platformVersion = 2021.1


### PR DESCRIPTION
bumps allowed plugin versions to include latest 2022.1 releases and upcoming releases 2022.2