### PR TITLE
Intellij 2026.1 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .gradle
 .idea
 build
+.intellijPlatform

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 <!-- Keep a Changelog guide -> https://keepachangelog.com -->
 
 # Docker Registry Explorer Changelog
+## [1.1.2-stable] - 2026-04-13
+### Added
+- Support for 2026.1+ versions
 
 ## [1.1.0-stable] - 2023-01-02
 ### Added

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
     // Java support
     id("java")
     // Kotlin support
-    id("org.jetbrains.kotlin.jvm") version "1.9.22"
+    id("org.jetbrains.kotlin.jvm") version "2.3.0"
     // gradle-intellij-plugin - read more: https://github.com/JetBrains/gradle-intellij-plugin
     id("org.jetbrains.intellij.platform") version "2.1.0"
     // gradle-changelog-plugin - read more: https://github.com/JetBrains/gradle-changelog-plugin
@@ -67,14 +67,17 @@ detekt {
 }
 
 tasks {
+    withType<org.jetbrains.intellij.platform.gradle.tasks.BuildPluginTask> {
+        archiveVersion.set(pluginVersion)
+    }
     // Set the compatibility versions to 21
     withType<JavaCompile> {
         sourceCompatibility = "21"
         targetCompatibility = "21"
     }
-    listOf("compileKotlin", "compileTestKotlin").forEach {
-        getByName<KotlinCompile>(it) {
-            kotlinOptions.jvmTarget = "21"
+    withType<KotlinCompile> {
+        compilerOptions {
+            jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_21)
         }
     }
 
@@ -115,5 +118,9 @@ tasks {
         // Specify pre-release label to publish the plugin in a custom Release Channel automatically. Read more:
         // https://jetbrains.org/intellij/sdk/docs/tutorials/build_system/deployment.html#specifying-a-release-channel
         channels.set(listOf(pluginVersion.split('-').getOrElse(1) { "default" }.split('.').first()))
+    }
+
+    buildSearchableOptions {
+        enabled = false
     }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,4 @@
 import io.gitlab.arturbosch.detekt.Detekt
-import org.jetbrains.changelog.closure
 import org.jetbrains.changelog.markdownToHTML
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
@@ -7,15 +6,15 @@ plugins {
     // Java support
     id("java")
     // Kotlin support
-    id("org.jetbrains.kotlin.jvm") version "1.4.20"
+    id("org.jetbrains.kotlin.jvm") version "1.9.22"
     // gradle-intellij-plugin - read more: https://github.com/JetBrains/gradle-intellij-plugin
-    id("org.jetbrains.intellij") version "0.6.5"
+    id("org.jetbrains.intellij.platform") version "2.1.0"
     // gradle-changelog-plugin - read more: https://github.com/JetBrains/gradle-changelog-plugin
-    id("org.jetbrains.changelog") version "0.6.2"
+    id("org.jetbrains.changelog") version "2.2.0"
     // detekt linter - read more: https://detekt.github.io/detekt/gradle.html
-    id("io.gitlab.arturbosch.detekt") version "1.14.2"
+    id("io.gitlab.arturbosch.detekt") version "1.23.5"
     // ktlint linter - read more: https://github.com/JLLeitschuh/ktlint-gradle
-    id("org.jlleitschuh.gradle.ktlint") version "9.4.1"
+    id("org.jlleitschuh.gradle.ktlint") version "12.1.0"
 }
 
 // Import variables from gradle.properties file
@@ -39,64 +38,58 @@ version = pluginVersion
 // Configure project's dependencies
 repositories {
     mavenCentral()
-    jcenter()
     maven("https://jitpack.io")
+    intellijPlatform {
+        defaultRepositories()
+    }
 }
 dependencies {
+    intellijPlatform {
+        create(platformType, platformVersion)
+        instrumentationTools()
+        pluginVerifier()
+    }
+
     implementation("com.github.ExidCuter:DockerRegistryV2Wrapper:master-SNAPSHOT")
-    detektPlugins("io.gitlab.arturbosch.detekt:detekt-formatting:1.14.2")
+    detektPlugins("io.gitlab.arturbosch.detekt:detekt-formatting:1.23.5")
 }
 
 // Configure gradle-intellij-plugin plugin.
 // Read more: https://github.com/JetBrains/gradle-intellij-plugin
-intellij {
-    pluginName = pluginName_
-    version = platformVersion
-    type = platformType
-    downloadSources = platformDownloadSources.toBoolean()
-    updateSinceUntilBuild = true
-
-    // Plugin Dependencies. Uses `platformPlugins` property from the gradle.properties file.
-    setPlugins(*platformPlugins.split(',').map(String::trim).filter(String::isNotEmpty).toTypedArray())
-}
+// No longer needed: intellij { ... } is replaced by intellijPlatform { ... } in dependencies and repositories
+// and by tasks configuration for specific platform tasks.
 
 // Configure detekt plugin.
 // Read more: https://detekt.github.io/detekt/kotlindsl.html
 detekt {
-    config = files("./detekt-config.yml")
+    config.setFrom("./detekt-config.yml")
     buildUponDefaultConfig = true
-
-    reports {
-        html.enabled = false
-        xml.enabled = false
-        txt.enabled = false
-    }
 }
 
 tasks {
-    // Set the compatibility versions to 1.8
+    // Set the compatibility versions to 21
     withType<JavaCompile> {
-        sourceCompatibility = "1.8"
-        targetCompatibility = "1.8"
+        sourceCompatibility = "21"
+        targetCompatibility = "21"
     }
     listOf("compileKotlin", "compileTestKotlin").forEach {
         getByName<KotlinCompile>(it) {
-            kotlinOptions.jvmTarget = "1.8"
+            kotlinOptions.jvmTarget = "21"
         }
     }
 
     withType<Detekt> {
-        jvmTarget = "1.8"
+        jvmTarget = "21"
     }
 
     patchPluginXml {
-        version(pluginVersion)
-        sinceBuild(pluginSinceBuild)
-        untilBuild(pluginUntilBuild)
+        version = pluginVersion
+        sinceBuild = pluginSinceBuild
+        untilBuild = pluginUntilBuild
 
         // Extract the <!-- Plugin description --> section from README.md and provide for the plugin's manifest
-        pluginDescription(
-            closure {
+        pluginDescription =
+            provider {
                 File("./README.md").readText().lines().run {
                     val start = "<!-- Plugin description -->"
                     val end = "<!-- Plugin description end -->"
@@ -107,26 +100,20 @@ tasks {
                     subList(indexOf(start) + 1, indexOf(end))
                 }.joinToString("\n").run { markdownToHTML(this) }
             }
-        )
 
         // Get the latest available change notes from the changelog file
-        changeNotes(
-            closure {
-                changelog.getLatest().toHTML()
+        changeNotes =
+            provider {
+                changelog.renderItem(changelog.getLatest(), org.jetbrains.changelog.Changelog.OutputType.HTML)
             }
-        )
-    }
-
-    runPluginVerifier {
-        ideVersions(pluginVerifierIdeVersions)
     }
 
     publishPlugin {
         dependsOn("patchChangelog")
-        token(System.getenv("PUBLISH_TOKEN"))
+        token.set(System.getenv("PUBLISH_TOKEN"))
         // pluginVersion is based on the SemVer (https://semver.org) and supports pre-release labels, like 2.1.7-alpha.3
         // Specify pre-release label to publish the plugin in a custom Release Channel automatically. Read more:
         // https://jetbrains.org/intellij/sdk/docs/tutorials/build_system/deployment.html#specifying-a-release-channel
-        channels(pluginVersion.split('-').getOrElse(1) { "default" }.split('.').first())
+        channels.set(listOf(pluginVersion.split('-').getOrElse(1) { "default" }.split('.').first()))
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,14 +4,14 @@
 pluginGroup = com.github.exidcuter.dockerregistryexplorer
 pluginName_ = docker-registry-explorer
 pluginVersion = 1.1.2-stable
-pluginSinceBuild = 243
-pluginUntilBuild = 261.*
+pluginSinceBuild = 261
+pluginUntilBuild = 271.*
 # Plugin Verifier integration -> https://github.com/JetBrains/gradle-intellij-plugin#plugin-verifier-dsl
 # See https://jb.gg/intellij-platform-builds-list for available build versions
-pluginVerifierIdeVersions = 2024.3.4.1
+pluginVerifierIdeVersions = 2026.1
 
-platformType = IC
-platformVersion = 2024.3.4.1
+platformType = IU
+platformVersion = 2026.1
 platformDownloadSources = true
 # Plugin Dependencies -> https://www.jetbrains.org/intellij/sdk/docs/basics/plugin_structure/plugin_dependencies.html
 # Example: platformPlugins = com.intellij.java, com.jetbrains.php:203.4449.22

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,14 +4,14 @@
 pluginGroup = com.github.exidcuter.dockerregistryexplorer
 pluginName_ = docker-registry-explorer
 pluginVersion = 1.1.2-stable
-pluginSinceBuild = 203
+pluginSinceBuild = 243
 pluginUntilBuild = 261.*
 # Plugin Verifier integration -> https://github.com/JetBrains/gradle-intellij-plugin#plugin-verifier-dsl
 # See https://jb.gg/intellij-platform-builds-list for available build versions
-pluginVerifierIdeVersions = 2020.3, 2021.1, 2021.2, 2022.1, 2022.2, 2022.3
+pluginVerifierIdeVersions = 2024.3.4.1
 
 platformType = IC
-platformVersion = 2021.1
+platformVersion = 2024.3.4.1
 platformDownloadSources = true
 # Plugin Dependencies -> https://www.jetbrains.org/intellij/sdk/docs/basics/plugin_structure/plugin_dependencies.html
 # Example: platformPlugins = com.intellij.java, com.jetbrains.php:203.4449.22

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,9 +3,9 @@
 
 pluginGroup = com.github.exidcuter.dockerregistryexplorer
 pluginName_ = docker-registry-explorer
-pluginVersion = 1.1.0-stable
+pluginVersion = 1.1.2-stable
 pluginSinceBuild = 203
-pluginUntilBuild = 245.*
+pluginUntilBuild = 261.*
 # Plugin Verifier integration -> https://github.com/JetBrains/gradle-intellij-plugin#plugin-verifier-dsl
 # See https://jb.gg/intellij-platform-builds-list for available build versions
 pluginVerifierIdeVersions = 2020.3, 2021.1, 2021.2, 2022.1, 2022.2, 2022.3

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
+#Mon Apr 13 09:49:38 CEST 2026
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.3.0-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/java/com/github/exidcuter/dockerregistryexplorer/ui/ExplorerToolWindowFactory.java
+++ b/src/main/java/com/github/exidcuter/dockerregistryexplorer/ui/ExplorerToolWindowFactory.java
@@ -79,7 +79,7 @@ public class ExplorerToolWindowFactory implements ToolWindowFactory {
 
         this.panel = repositoriesPanel;
 
-        Content content = ContentFactory.SERVICE.getInstance().createContent(repositoriesPanel, "", false);
+        Content content = ContentFactory.getInstance().createContent(repositoriesPanel, "", false);
         toolWindow.addContentManagerListener(new ContentManagerListener() {
             @Override
             public void contentAdded(@NotNull ContentManagerEvent event) {
@@ -145,7 +145,7 @@ public class ExplorerToolWindowFactory implements ToolWindowFactory {
             RegistryErrorNotifier.notifySuccess(project, "Adding docker registry. This can take a while...");
 
             dockerRepositories.add(new DockerRegistry(dialog.getLoginCredentials(), true));
-            Content content = ContentFactory.SERVICE.getInstance().createContent(panel, "", false);
+            Content content = ContentFactory.getInstance().createContent(panel, "", false);
             toolWindow.getContentManager().addContent(content);
         }
     }

--- a/src/main/kotlin/com/github/exidcuter/dockerregistryexplorer/MyBundle.kt
+++ b/src/main/kotlin/com/github/exidcuter/dockerregistryexplorer/MyBundle.kt
@@ -8,14 +8,19 @@ import org.jetbrains.annotations.PropertyKey
 private const val BUNDLE = "messages.MyBundle"
 
 object MyBundle : AbstractBundle(BUNDLE) {
+    @Suppress("SpreadOperator")
+    @JvmStatic
+    fun message(
+        @PropertyKey(resourceBundle = BUNDLE) key: String,
+        vararg params: Any,
+    ) = getMessage(key, *params)
 
     @Suppress("SpreadOperator")
     @JvmStatic
-    fun message(@PropertyKey(resourceBundle = BUNDLE) key: String, vararg params: Any) = getMessage(key, *params)
-
-    @Suppress("SpreadOperator")
-    @JvmStatic
-    fun messagePointer(@PropertyKey(resourceBundle = BUNDLE) key: String, vararg params: Any) = run {
+    fun messagePointer(
+        @PropertyKey(resourceBundle = BUNDLE) key: String,
+        vararg params: Any,
+    ) = run {
         message(key, *params)
     }
 }


### PR DESCRIPTION
* update gradle to 9.3.0
* update jvm to 21
* migrate intellij to intellijPlatform
* Changed platformtype from IC (intellij community) to IU (intellij professional) since community is integrated into professional since 2025
* ui/explorertoolwindow.java: Refactor ContentFactory.SERVICE.getInstance().createContent(repositoriesPanel, "", false); into ContentFactory.getInstance().createContent(repositoriesPanel, "", false);
No idea if this is actually needed or not.

This update has been significantly supported through AI since I do not have sufficient experience with java in general.
However, it does work for manual installing in pycharm using the generated .zip file